### PR TITLE
ci: auto-commit dist rebuild on renovate PRs

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Node.js 20.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.x
+          node-version: '24'
 
       - name: Build Action
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,33 @@ jobs:
         run: |
           npm run all
 
+  commit-dist:
+    needs: build
+    if: |
+      github.event_name == 'pull_request' &&
+      startsWith(github.head_ref, 'renovate/') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.actor == github.repository_owner || github.actor == 'renovate-mike[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20.x
+      - run: npm ci && npm run build && npm run package
+      - name: Commit rebuilt dist
+        run: |
+          git config user.name "Mike Penz"
+          git config user.email "opensource-bot@mikepenz.dev"
+          git add dist/
+          git diff --staged --quiet || git commit -m "chore: rebuild dist for renovate"
+          git push https://x-access-token:${{ secrets.RENOVATE_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.event.pull_request.head.ref }}
+
   release:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
       - name: Install NPM
         run: |
           npm install
@@ -38,7 +42,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.x
+          node-version: '24'
       - run: npm ci && npm run build && npm run package
       - name: Commit rebuilt dist
         run: |


### PR DESCRIPTION
Adds a `commit-dist` job to the CI pipeline that automatically rebuilds and commits `dist/` when Renovate opens a dependency update PR.

This matches the same pattern already used in `action-junit-report` and `deployments`.