### PR TITLE
docs: redesign README as a landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,99 @@
-## Fork
-
-This is a fork from https://github.com/softprops/action-gh-release with various patches and modifications applied - Please refer to the original action for any questions.
-
-<div align="center">
-  📦 :octocat:
-</div>
-<h1 align="center">
-  action gh-release
-</h1>
+<h1 align="center">action-gh-release</h1>
 
 <p align="center">
-   A GitHub Action for creating GitHub Releases on Linux, Windows, and macOS virtual environments
+  <a href="https://github.com/mikepenz/action-gh-release/releases/latest"><img src="https://img.shields.io/github/v/release/mikepenz/action-gh-release?label=release&color=1a7f37" alt="Latest release"></a>
+  <a href="https://github.com/mikepenz/action-gh-release/actions/workflows/main.yml"><img src="https://github.com/mikepenz/action-gh-release/actions/workflows/main.yml/badge.svg" alt="Build status"></a>
+  <a href="https://github.com/mikepenz/action-gh-release/blob/main/LICENSE"><img src="https://img.shields.io/github/license/mikepenz/action-gh-release?color=1a7f37" alt="License"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/mikepenz/action-gh-release"><img src="https://api.securityscorecards.dev/projects/github.com/mikepenz/action-gh-release/badge" alt="OpenSSF Scorecard"></a>
 </p>
 
-<div align="center">
-  <img src="demo.png"/>
-</div>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="art/hero-dark.svg">
+    <img src="art/hero-light.svg" width="100%" alt="action-gh-release: a tag push runs a workflow step that publishes a GitHub Release with its assets uploaded">
+  </picture>
+</p>
 
-<br />
+<p align="center">
+  <a href="#-quickstart">Quickstart</a> •
+  <a href="#-showcase">Showcase</a> •
+  <a href="#reference">Reference</a> •
+  <a href="#inputs">Inputs</a>
+</p>
+
+| | |
+| --- | --- |
+| 🚀 **One step, one release** | Creates or updates the release for a tag and uploads every matching asset. |
+| 🌍 **Runs anywhere** | Linux, Windows and macOS runners — no Docker, `node24` JavaScript action. |
+| 📝 **Release notes included** | `generate_release_notes`, `body`, `body_path`, or append to what is already there. |
+| 📦 **Glob-based assets** | Newline-delimited globs, uploaded in parallel, optionally in a fixed order. |
+| 🛟 **Safe under concurrency** | Uploads into a draft, then publishes — and `on_tag_conflict` handles a racing job. |
+| 🔗 **Usable outputs** | `url`, `id`, `upload_url`, and a JSON `assets` array for downstream steps. |
+
+## 🚀 Quickstart
+
+**1. Grant the job permission to write releases**
+
+```yaml
+permissions:
+  contents: write
+```
+
+**2. Add the step, gated on a tag push**
+
+```yaml
+name: Main
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: mikepenz/action-gh-release@v3
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            build/*.zip
+            build/checksums.txt
+```
+
+**3. Push a tag**
+
+```bash
+git tag v1.2.0 && git push origin v1.2.0
+```
+
+The release is created as a draft, the assets are uploaded, and it is published once
+they are all there. See [inputs](#inputs) for everything you can customize.
+
+## 📸 Showcase
+
+<p align="center">
+  <img src="demo.png" width="100%" alt="A GitHub release page created by the action, with uploaded assets listed">
+</p>
+
+> The screenshot above is captured by hand and needs a manual refresh when the GitHub
+> release UI changes. The hero above it is generated and always matches this README.
+
+---
+
+# Reference
+
+| Topic | |
+| --- | --- |
+| [Usage](#-usage) | Tag gating and the shape of a typical workflow |
+| [Inputs](#inputs) | Every `with:` key |
+| [Outputs](#outputs) | Values other steps can read |
+| [Environment variables](#environment-variables) | Deprecated `env:` fallbacks |
+| [Permissions](#permissions) | Token scopes the action needs |
+| [Fork](#fork) | Relationship to the upstream action |
 
 ## 🤸 Usage
 
@@ -58,6 +134,10 @@ The following are optional as `step.with` keys
 | `draft`                    | Boolean | Indicator of whether or not this release is a draft                                                                                                                                                                                                                                                                                                                                                                                             |
 | `prerelease`               | Boolean | Indicator of whether or not is a prerelease                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `files`                    | String  | Newline-delimited globs of paths to assets to upload for release                                                                                                                                                                                                                                                                                                                                                                                |
+| `working_directory`        | String  | Base directory to resolve the `files` globs against. Defaults to the job working directory                                                                                                                                                                                                                                                                                                                                                      |
+| `overwrite_files`          | Boolean | Overwrite existing release assets with the same name. Defaults to `true`                                                                                                                                                                                                                                                                                                                                                                        |
+| `preserve_order`           | Boolean | Upload the assets sequentially so their order on the release matches the `files` order                                                                                                                                                                                                                                                                                                                                                          |
+| `concurrency`              | String  | Maximum number of assets to upload in parallel. Defaults to `4`. Ignored when `preserve_order` is `true`                                                                                                                                                                                                                                                                                                                                        |
 | `name`                     | String  | Name of the release. defaults to tag name                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `tag_name`                 | String  | Name of a tag. defaults to `github.ref`                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `fail_on_unmatched_files`  | Boolean | Indicator of whether to fail if any of the `files` globs match nothing                                                                                                                                                                                                                                                                                                                                                                          |
@@ -70,6 +150,7 @@ The following are optional as `step.with` keys
 | `token`                    | String  | Secret GitHub Personal Access Token. Defaults to `${{ github.token }}`                                                                                                                                                                                                                                                                                                                                                                          |
 | `discussion_category_name` | String  | If specified, a discussion of the specified category is created and linked to the release. The value must be a category that already exists in the repository. For more information, see ["Managing categories for discussions in your repository."](https://docs.github.com/en/discussions/managing-discussions-for-your-community/managing-categories-for-discussions-in-your-repository)                                                     |
 | `generate_release_notes`   | Boolean | Whether to automatically generate the name and body for this release. If name is specified, the specified name will be used; otherwise, a name will be automatically generated. If body is specified, the body will be pre-pended to the automatically generated notes. See the [GitHub docs for this feature](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) for more information |
+| `previous_tag`             | String  | When `generate_release_notes` is `true`, use this tag as the starting point instead of letting GitHub auto-detect the previous release                                                                                                                                                                                                                                                                                                           |
 | `append_body`              | Boolean | Append to existing body instead of overwriting it                                                                                                                                                                                                                                                                                                                                                                                               |
 
 💡 When providing a `body` and `body_path` at the same time, `body_path` will be
@@ -121,5 +202,9 @@ permissions:
 ```
 
 [GitHub token permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) can be set for an individual job, workflow, or for Actions as a whole.
+
+## Fork
+
+This is a fork from https://github.com/softprops/action-gh-release with various patches and modifications applied - Please refer to the original action for any questions.
 
 Doug Tangren (softprops) 2019

--- a/art/hero-dark.svg
+++ b/art/hero-dark.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="470" viewBox="0 0 1200 470" role="img" aria-labelledby="t d">
+  <title id="t">action-gh-release</title>
+  <desc id="d">A GitHub Action that turns a tag push into a published GitHub Release with its assets uploaded.</desc>
+  <rect width="1200" height="470" rx="24" fill="#0d1117"/>
+  <rect x="1" y="1" width="1198" height="468" rx="23" fill="none" stroke="#30363d"/>
+
+  <g transform="translate(64 118)">
+    <text font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="18" fill="#3fb950" letter-spacing="1.5">GITHUB ACTION &#183; NODE 24</text>
+    <text y="74" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="56" font-weight="700" fill="#e6edf3">action-gh-release</text>
+    <text y="128" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="23" fill="#9198a1">Create GitHub Releases and upload their</text>
+    <text y="160" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="23" fill="#9198a1">assets, straight from a workflow step.</text>
+    <g transform="translate(0 198)"><rect x="0" y="0" width="58" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="29" y="18" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">Linux</text><rect x="66" y="0" width="73" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="102.5" y="18" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">Windows</text><rect x="147" y="0" width="58" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="176" y="18" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">macOS</text></g>
+  </g>
+
+  
+  <g transform="translate(606 58)">
+    <rect width="530" height="76" rx="12" fill="#161b22" stroke="#30363d"/>
+    <rect width="4" height="76" rx="2" fill="#3fb950"/>
+    <text x="24" y="30" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="18" font-weight="600" fill="#9198a1" letter-spacing="0.6">TAG PUSH</text>
+    <text x="24" y="60" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="20" fill="#e6edf3">git push origin v1.2.0</text>
+    
+  </g>
+  <path d="M646 142 v14" stroke="#3fb950" stroke-width="2"/>
+  <path d="M640 149 l6 7 6 -7" fill="none" stroke="#3fb950" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g transform="translate(606 172)">
+    <rect width="530" height="110" rx="12" fill="#161b22" stroke="#30363d"/>
+    <rect width="4" height="110" rx="2" fill="#3fb950"/>
+    <text x="24" y="30" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="18" font-weight="600" fill="#9198a1" letter-spacing="0.6">WORKFLOW STEP</text>
+    <text x="24" y="60" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="20" fill="#e6edf3">uses: mikepenz/action-gh-release@v3</text>
+    <g transform="translate(24 0)"><rect x="0" y="74" width="66" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="33" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">files:</text><rect x="74" y="74" width="195" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="171.5" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">generate_release_notes:</text></g>
+  </g>
+  <path d="M646 290 v14" stroke="#3fb950" stroke-width="2"/>
+  <path d="M640 297 l6 7 6 -7" fill="none" stroke="#3fb950" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g transform="translate(606 320)">
+    <rect width="530" height="110" rx="12" fill="#161b22" stroke="#30363d"/>
+    <rect width="4" height="110" rx="2" fill="#3fb950"/>
+    <text x="24" y="30" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="18" font-weight="600" fill="#9198a1" letter-spacing="0.6">PUBLISHED RELEASE</text>
+    <text x="24" y="60" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="20" fill="#e6edf3">Release v1.2.0</text>
+    <g transform="translate(24 0)"><rect x="0" y="74" width="73" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="36.5" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">app.zip</text><rect x="81" y="74" width="119" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="140.5" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">checksums.txt</text><rect x="208" y="74" width="104" height="26" rx="13" fill="#0d1117" stroke="#30363d"/><text x="260" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#9198a1" text-anchor="middle">outputs.url</text></g>
+  </g>
+</svg>

--- a/art/hero-light.svg
+++ b/art/hero-light.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="470" viewBox="0 0 1200 470" role="img" aria-labelledby="t d">
+  <title id="t">action-gh-release</title>
+  <desc id="d">A GitHub Action that turns a tag push into a published GitHub Release with its assets uploaded.</desc>
+  <rect width="1200" height="470" rx="24" fill="#ffffff"/>
+  <rect x="1" y="1" width="1198" height="468" rx="23" fill="none" stroke="#d0d7de"/>
+
+  <g transform="translate(64 118)">
+    <text font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="18" fill="#1a7f37" letter-spacing="1.5">GITHUB ACTION &#183; NODE 24</text>
+    <text y="74" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="56" font-weight="700" fill="#1f2328">action-gh-release</text>
+    <text y="128" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="23" fill="#59636e">Create GitHub Releases and upload their</text>
+    <text y="160" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="23" fill="#59636e">assets, straight from a workflow step.</text>
+    <g transform="translate(0 198)"><rect x="0" y="0" width="58" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="29" y="18" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">Linux</text><rect x="66" y="0" width="73" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="102.5" y="18" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">Windows</text><rect x="147" y="0" width="58" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="176" y="18" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">macOS</text></g>
+  </g>
+
+  
+  <g transform="translate(606 58)">
+    <rect width="530" height="76" rx="12" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect width="4" height="76" rx="2" fill="#1a7f37"/>
+    <text x="24" y="30" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="18" font-weight="600" fill="#59636e" letter-spacing="0.6">TAG PUSH</text>
+    <text x="24" y="60" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="20" fill="#1f2328">git push origin v1.2.0</text>
+    
+  </g>
+  <path d="M646 142 v14" stroke="#1a7f37" stroke-width="2"/>
+  <path d="M640 149 l6 7 6 -7" fill="none" stroke="#1a7f37" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g transform="translate(606 172)">
+    <rect width="530" height="110" rx="12" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect width="4" height="110" rx="2" fill="#1a7f37"/>
+    <text x="24" y="30" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="18" font-weight="600" fill="#59636e" letter-spacing="0.6">WORKFLOW STEP</text>
+    <text x="24" y="60" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="20" fill="#1f2328">uses: mikepenz/action-gh-release@v3</text>
+    <g transform="translate(24 0)"><rect x="0" y="74" width="66" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="33" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">files:</text><rect x="74" y="74" width="195" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="171.5" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">generate_release_notes:</text></g>
+  </g>
+  <path d="M646 290 v14" stroke="#1a7f37" stroke-width="2"/>
+  <path d="M640 297 l6 7 6 -7" fill="none" stroke="#1a7f37" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g transform="translate(606 320)">
+    <rect width="530" height="110" rx="12" fill="#f6f8fa" stroke="#d0d7de"/>
+    <rect width="4" height="110" rx="2" fill="#1a7f37"/>
+    <text x="24" y="30" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="18" font-weight="600" fill="#59636e" letter-spacing="0.6">PUBLISHED RELEASE</text>
+    <text x="24" y="60" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="20" fill="#1f2328">Release v1.2.0</text>
+    <g transform="translate(24 0)"><rect x="0" y="74" width="73" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="36.5" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">app.zip</text><rect x="81" y="74" width="119" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="140.5" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">checksums.txt</text><rect x="208" y="74" width="104" height="26" rx="13" fill="#ffffff" stroke="#d0d7de"/><text x="260" y="92" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#59636e" text-anchor="middle">outputs.url</text></g>
+  </g>
+</svg>


### PR DESCRIPTION
Rebuilds the README as a landing page: a first-time visitor should see what the action does before scrolling.

### Above the fold
- Generated **light/dark SVG hero** (`art/hero-*.svg`) — a system map of `git push origin v1.2.0` → workflow step → published release with assets. Swapped via `<picture>` + `prefers-color-scheme`, relative paths so it renders in this PR too.
- Badges (release, build, license, OpenSSF Scorecard), a 6-row claim table, and a 3-step Quickstart with a copy-pasteable workflow.

### Below the fold
`# Reference` keeps **every line of the previous README**, only demoted — including the fork note, now at the bottom as `## Fork`.

### Drift fixed in the same pass
- Inputs table was missing `working_directory`, `overwrite_files`, `preserve_order`, `concurrency`, `previous_tag` — added from `action.yml`.
- Quickstart example pinned to `@v3` instead of the non-resolving `@{latest}`.

### Notes
- Both SVGs come from one generator script, so light and dark cannot drift. The script is not committed; ping me if you want it in `scripts/`.
- `demo.png` is unchanged and still hand-captured — this repo has no screenshot tooling to generate it. The README now says so explicitly instead of pretending it is current.
